### PR TITLE
unsubscribe on component destroy

### DIFF
--- a/force-app/main/default/aura/Redux/Redux.cmp
+++ b/force-app/main/default/aura/Redux/Redux.cmp
@@ -1,5 +1,6 @@
 <aura:component description="Redux">
     <ltng:require scripts="{!$Resource.redux}"/>
+    <aura:handler name="destroy" value="{!this}" action="{!c.handleUnsubscribe}"/>
     <aura:attribute name="name" type="string" default="redux" />
     <aura:method name="createStore" action="{!c.createStore}">
         <aura:attribute name="name" type="string" />

--- a/force-app/main/default/aura/Redux/ReduxController.js
+++ b/force-app/main/default/aura/Redux/ReduxController.js
@@ -163,7 +163,7 @@
 
             handleChanges();
 
-            window.reduxStore[reduxName].subscribe(handleChanges);
+            component.unsubscribe = window.reduxStore[reduxName].subscribe(handleChanges);
             target.dispatch = window.reduxStore[reduxName].dispatch;
         } else {
             if(window.subscriberQueue && window.subscriberQueue[reduxName]) {
@@ -179,6 +179,11 @@
                 }];
             }
         }
+    },
+    handleUnsubscribe: function(component) {
+      if (component.unsubscribe) {
+        component.unsubscribe();
+      }
     }
 
 })


### PR DESCRIPTION
this should handle removing event listeners whenever the redux component is destroyed (which typically happens whenever a custom component is destroyed)

i can try to write some tests this weekend to validate it, but hopefully it isn't too disruptive (hoping for a net gain in performance)

fixes #17 